### PR TITLE
chore: improve .gitignore with common Rust project entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,39 @@
+# Build
 /target
+
+# IDE
 /.idea
 /.vscode
 /.classpath
+
+# AI assistants
 /.claude
+
+# Environment & config
 .env
 /Cargo.lock
 /echo-agent.yaml
+
+# SQLite databases
+*.sqlite
+*.sqlite3
+*.db
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Editor swap/backup files
+*.swp
+*.swo
+*~
+
+# Rust coverage & profiling
+*.profraw
+*.profdata
+lcov.info
+tarpaulin-report.html
+coverage/
+
+# Debug
+*.pdb


### PR DESCRIPTION
## Summary

- Add ignore rules for SQLite databases (`*.sqlite`, `*.sqlite3`, `*.db`), since the project has a `sqlite` feature
- Add ignore rules for OS generated files (`.DS_Store`, `Thumbs.db`)
- Add ignore rules for editor swap/backup files (`*.swp`, `*.swo`, `*~`)
- Add ignore rules for Rust coverage & profiling artifacts (`*.profraw`, `*.profdata`, `lcov.info`, `tarpaulin-report.html`, `coverage/`)
- Add ignore rule for debug symbols (`*.pdb`)
- Add section comments for better readability

## Motivation

The current `.gitignore` only has 8 entries. This PR adds commonly needed entries for a Rust workspace project to prevent accidentally committing generated/temporary files.

No code logic changes — only `.gitignore` is modified.